### PR TITLE
Add proxy config field into yaml file

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,7 @@ nrinfragent_service_enabled: "yes"
 nrinfragent_service_state: "started"
 nrinfragent_config:
   license_key: YOUR_LICENSE_KEY
+  proxy: ""
 nrinfragent_integrations: []
 nrinfragent_tarball_url: "http://download.newrelic.com/infrastructure_agent/binaries/linux/{{ nrinfragent_architecture }}/newrelic-infra_linux_{{ nrinfragent_tarball_version }}_{{ nrinfragent_architecture }}.tar.gz"
 nrinfragent_tarball_download_dir: "/opt"

--- a/tasks/install_targz.yml
+++ b/tasks/install_targz.yml
@@ -34,7 +34,6 @@
     NRIA_MODE: "{{ nrinfragent_tarball_mode | default('') }}"
     NRIA_USER: "{{ nrinfragent_tarball_user | default('') }}"
     NRIA_CONFIG_FILE: "{{ nrinfragent_tarball_config_file | default('') }}"
-
     NRIA_PROXY: "{{ nrinfragent_config['proxy'] | default('') }}"
     NRIA_LICENSE_KEY: "{{ nrinfragent_config['license_key'] | default('') }}"
   become: true

--- a/tasks/install_targz.yml
+++ b/tasks/install_targz.yml
@@ -35,6 +35,7 @@
     NRIA_USER: "{{ nrinfragent_tarball_user | default('') }}"
     NRIA_CONFIG_FILE: "{{ nrinfragent_tarball_config_file | default('') }}"
 
+    NRIA_PROXY: "{{ nrinfragent_config['proxy'] | default('') }}"
     NRIA_LICENSE_KEY: "{{ nrinfragent_config['license_key'] | default('') }}"
   become: true
   when: archive_contents is defined and archive_contents.changed == True


### PR DESCRIPTION
Implementa maneira de configurar proxy no arquivo .yml para resolver o problema das VMS de gtk-v-man01 (ATL) não conseguir utilizar o proxy definido via env var.


# Outros
[issue no repositório principal](https://github.com/newrelic/infrastructure-agent-ansible/issues/96)